### PR TITLE
remove user from avro scripts

### DIFF
--- a/create_dns_avro_parquet.hql
+++ b/create_dns_avro_parquet.hql
@@ -18,7 +18,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ${hiveconf:dbname}.dns (
 PARTITIONED BY (y INT, m INT, d INT, h int)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS PARQUET
-LOCATION '/user/${hiveconf:huser}/dns/hive'
+LOCATION '${hiveconf:huser}/dns/hive'
 TBLPROPERTIES ('avro.schema.literal'='{
     "type":   "record"
   , "name":   "DnsRecord"

--- a/create_flow_avro_parquet.hql
+++ b/create_flow_avro_parquet.hql
@@ -34,7 +34,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ${hiveconf:dbname}.flow (
 PARTITIONED BY (y INT, m INT, d INT, h int)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS PARQUET
-LOCATION '/user/${hiveconf:huser}/flow/hive'
+LOCATION '${hiveconf:huser}/flow/hive'
 TBLPROPERTIES ('avro.schema.literal'='{
     "type":   "record"
   , "name":   "FlowRecord"


### PR DESCRIPTION
In duxbay.conf file HUSER variable may contains "/user" , it is not needed in in the load to dns avro script 
