### PR TITLE
issue39_path_separation

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -9,7 +9,8 @@ DBNAME='duxbury'
 HUSER='/user/duxbury'
 DSOURCES='flow'
 DFOLDERS=('binary' 'csv' 'hive' 'stage')
-DPATH=${HUSER}/${DSOURCE}/csv/y=${YR}/m=${MH}/d=${DY}/*
+DNS_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
+FLOW_PATH=${HUSER}/${DSOURCE}/csv/y=${YR}/m=${MH}/d=${DY}/*
 HPATH=${HUSER}/${DSOURCE}/${DFOLDER}/lda${FDATE}
 
 KRB_AUTH=false


### PR DESCRIPTION
DPATH is now two separate variables:
FLOWPATH - the location of the ingested netflow data
DNSPATH - the location of the ingested DNS data

Needed to merge DNS analysis into 1.0.1
