### PR TITLE
fix user path in avro scripts

### DIFF
--- a/create_dns_avro_parquet.hql
+++ b/create_dns_avro_parquet.hql
@@ -16,7 +16,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ${hiveconf:dbname}.dns (
 PARTITIONED BY (y INT, m INT, d INT, h int)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS PARQUET
-LOCATION '/user/${hiveconf:huser}/dns/hive'
+LOCATION '${hiveconf:huser}/dns/hive'
 TBLPROPERTIES ('avro.schema.literal'='{
     "type":   "record"
   , "name":   "DnsRecord"

--- a/create_flow_avro_parquet.hql
+++ b/create_flow_avro_parquet.hql
@@ -34,7 +34,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ${hiveconf:dbname}.flow (
 PARTITIONED BY (y INT, m INT, d INT, h int)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS PARQUET
-LOCATION '/user/${hiveconf:huser}/flow/hive'
+LOCATION '${hiveconf:huser}/flow/hive'
 TBLPROPERTIES ('avro.schema.literal'='{
     "type":   "record"
   , "name":   "FlowRecord"


### PR DESCRIPTION
User path is duplicated when the tables are created (hql scripts)
