### PR TITLE
mpi_cmd

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -33,5 +33,5 @@ SPK_EXEC='400'
 SPK_EXEC_MEM='2048m'
 TOL='1e-6'
 
-
-
+MPI_CMD='mpiexec'
+MPI_PREP_CMD=''


### PR DESCRIPTION
Added MPI_CMD (MPI execution command) and MPI_PREP_CMD (pre MPI command, loading of env vars or some such as needed)

MPI execution now controlled by MPI_PREP_CMD and MPI_CMD.

MPI_PREP_CMD: command necessary to prepare for running MPI (loading of environment variables or somesuch)
MPI_CMD : command to execute MPI
