### PR TITLE
proc_count_to_conf

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -33,5 +33,15 @@ SPK_EXEC='400'
 SPK_EXEC_MEM='2048m'
 TOL='1e-6'
 
+
+# MPI configuration
+
+# command to run MPI
 MPI_CMD='mpiexec'
+
+# command to prepare system for MPI, eg. load environment variables
 MPI_PREP_CMD=''
+
+# number of processes to run in MPI
+PROCESS_COUNT=20
+


### PR DESCRIPTION
Process count for MPI now placed in duxbay.conf

Henceforth, user should not have to edit ml_ops.sh when installing the
ml pipeline (or when reconfiguring MPI).
