### PR TITLE
Modified source path for flow data (FLOW_PATH) to read from hive in duxbay.conf 

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -10,7 +10,7 @@ HUSER='/user/duxbury'
 DSOURCES='flow'
 DFOLDERS=('binary' 'csv' 'hive' 'stage')
 DNS_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
-FLOW_PATH=${HUSER}/${DSOURCE}/csv/y=${YR}/m=${MH}/d=${DY}/*
+FLOW_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
 HPATH=${HUSER}/${DSOURCE}/${DFOLDER}/lda${FDATE}
 
 #impala config


### PR DESCRIPTION
- Updated duxbay.conf FLOW_PATH to read from _hive_ folder instead of csv. 
- Removed the "*" at the end since is not need anymore. 

Related PR: https://github.com/Open-Network-Insight/oni-ml/pull/34
