### PR TITLE
Modified LPATH to split results into each data source

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -10,7 +10,7 @@ HUSER='/user/duxbury'
 DSOURCES='flow'
 DFOLDERS=('binary' 'csv' 'hive' 'stage')
 DNS_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
-FLOW_PATH=${HUSER}/${DSOURCE}/csv/y=${YR}/m=${MH}/d=${DY}/*
+FLOW_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
 HPATH=${HUSER}/${DSOURCE}/${DFOLDER}/lda${FDATE}
 
 #impala config

--- a/duxbay.conf
+++ b/duxbay.conf
@@ -24,7 +24,7 @@ KRB_USER=
 
 #local fs base user and data source config
 LUSER='/home/duxbury'
-LPATH=${LUSER}/ml/${FDATE}
+LPATH=${LUSER}/ml/${DSOURCE}/${FDATE}
 RPATH=${LUSER}/ipython/user/${FDATE}
 LDAPATH=${LUSER}/ml/oni-lda-c
 LIPATH=${LUSER}/ingest


### PR DESCRIPTION
LPATH was being determined by date only. Running Flow data and DNS data for the same day resulted into a file overlapping; common files like words, docs, final.gamma, final.beta. 
Having a folder for each data source we will avoid that overlapping. 
