### PR TITLE
ML's architecture change

### DIFF
--- a/duxbay.conf
+++ b/duxbay.conf
@@ -10,7 +10,7 @@ HUSER='/user/duxbury'
 DSOURCES='flow'
 DFOLDERS=('binary' 'csv' 'hive' 'stage')
 DNS_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
-FLOW_PATH=${HUSER}/${DSOURCE}/csv/y=${YR}/m=${MH}/d=${DY}/*
+FLOW_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
 HPATH=${HUSER}/${DSOURCE}/${DFOLDER}/lda${FDATE}
 
 #impala config

--- a/duxbay.conf
+++ b/duxbay.conf
@@ -24,7 +24,7 @@ KRB_USER=
 
 #local fs base user and data source config
 LUSER='/home/duxbury'
-LPATH=${LUSER}/ml/${FDATE}
+LPATH=${LUSER}/ml/${DSOURCE}/${FDATE}
 RPATH=${LUSER}/ipython/user/${FDATE}
 LDAPATH=${LUSER}/ml/oni-lda-c
 LIPATH=${LUSER}/ingest

--- a/duxbay.conf
+++ b/duxbay.conf
@@ -33,5 +33,15 @@ SPK_EXEC='400'
 SPK_EXEC_MEM='2048m'
 TOL='1e-6'
 
+
+# MPI configuration
+
+# command to run MPI
 MPI_CMD='mpiexec'
+
+# command to prepare system for MPI, eg. load environment variables
 MPI_PREP_CMD=''
+
+# number of processes to run in MPI
+PROCESS_COUNT=20
+

--- a/duxbay.conf
+++ b/duxbay.conf
@@ -33,5 +33,5 @@ SPK_EXEC='400'
 SPK_EXEC_MEM='2048m'
 TOL='1e-6'
 
-
-
+MPI_CMD='mpiexec'
+MPI_PREP_CMD=''


### PR DESCRIPTION
Corresponding changes to duxbay.conf based on PR https://github.com/Open-Network-Insight/oni-ml/pull/42 
- Added MPI command to duxbay.conf
- Added Process count to duxbay.conf
- Added DSOURCE to local folder so instead of ~ml/_date_ the ML results get saved in folder for each data source i.e. ~/ml/flow/_date_ ~/ml/dns/_date_
- Modified FLOW_PATH to be hive (now reading from avro parquet)
