### PR TITLE
changed y,m,d,h to strings

### DIFF
--- a/create_proxy_avro_parquet.hql
+++ b/create_proxy_avro_parquet.hql
@@ -32,10 +32,10 @@ bcappoper             string,
 fulluri               string
 )
 PARTITIONED BY (
-y int, 
-m int, 
-d int, 
-h int)
+y string, 
+m string, 
+d string, 
+h string)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS PARQUET
 LOCATION '${hiveconf:huser}/proxy/hive'


### PR DESCRIPTION
created to resolve internal db-614,

int's causing incorrect date partitions in avrò file structure
